### PR TITLE
Update shebang to use the environment's python

### DIFF
--- a/library/netbox_secret.py
+++ b/library/netbox_secret.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 


### PR DESCRIPTION
Helps prevent issues like:

```console
$ python -c 'import ansible.module_utils'
$ echo $?
0
$ library/netbox_secret.py
Traceback (most recent call last):
  File "library/netbox_secret.py", line 58, in <module>
    from ansible.module_utils.basic import *
ImportError: No module named ansible.module_utils.basic
(drac_automation)  ~/git/ansible/ansible-playbooks/drac_automation/ [master] which python
/Users/jedge/git/ansible/ansible-playbooks/drac_automation/virtualenvs/drac_automation/bin/python
```